### PR TITLE
.NET 8.0 & Nuget Dependency Updates

### DIFF
--- a/NuKeeper.Abstractions.Tests/NuKeeper.Abstractions.Tests.csproj
+++ b/NuKeeper.Abstractions.Tests/NuKeeper.Abstractions.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <PropertyGroup>

--- a/NuKeeper.Abstractions/NuKeeper.Abstractions.csproj
+++ b/NuKeeper.Abstractions/NuKeeper.Abstractions.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.1.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
-    <PackageReference Include="NuGet.Protocol" Version="5.11.0" />
+    <PackageReference Include="NuGet.Protocol" Version="6.13.1" />
   </ItemGroup>
 
 </Project>

--- a/NuKeeper.AzureDevOps/AzureDevOpsRestClient.cs
+++ b/NuKeeper.AzureDevOps/AzureDevOpsRestClient.cs
@@ -121,7 +121,7 @@ namespace NuKeeper.AzureDevOps
         {
             //return GetResource<Resource<Account>>("/_apis/accounts");
 
-
+            // https://stackoverflow.com/questions/73569095/how-to-get-current-user-information-from-rest-api-in-azure-devops
             // https://dev.azure.com/sist-sa-ucsb/_apis/ConnectionData
             var cd = GetResource<ConnectionData>("_apis/ConnectionData", previewApi: true).Result;
             var au = cd.authenticatedUser;
@@ -131,13 +131,13 @@ namespace NuKeeper.AzureDevOps
             account.accountName = au.Account;
             account.properties = new Dictionary<string, object>();
             account.properties.Add("Mail", account.accountName);
-            
+
             var raccount = new Resource<Account>();
             raccount.count = 1;
             var valList = new List<Account>();
             valList.Add(account);
             raccount.value = valList;
-            
+
             return Task.FromResult(raccount);
         }
 
@@ -206,7 +206,7 @@ namespace NuKeeper.AzureDevOps
             var autoCompleteContent = new StringContent(JsonConvert.SerializeObject(request), Encoding.UTF8, "application/json");
             return await PatchResource<PullRequest>($"{projectName}/_apis/git/repositories/{azureRepositoryId}/pullRequests/{pullRequestId}", autoCompleteContent);
         }
-        
+
         public async Task<IEnumerable<string>> GetGitRepositoryFileNames(string projectName, string azureRepositoryId)
         {
             var response = await GetResource<GitItemResource>($"{projectName}/_apis/git/repositories/{azureRepositoryId}/items?recursionLevel=Full");

--- a/NuKeeper.AzureDevOps/AzureDevOpsRestClient.cs
+++ b/NuKeeper.AzureDevOps/AzureDevOpsRestClient.cs
@@ -119,7 +119,26 @@ namespace NuKeeper.AzureDevOps
         // https://docs.microsoft.com/en-us/rest/api/azure/devops/account/accounts/list?view=azure-devops-rest-6.0
         public Task<Resource<Account>> GetCurrentUser()
         {
-            return GetResource<Resource<Account>>("/_apis/accounts");
+            //return GetResource<Resource<Account>>("/_apis/accounts");
+
+
+            // https://dev.azure.com/sist-sa-ucsb/_apis/ConnectionData
+            var cd = GetResource<ConnectionData>("_apis/ConnectionData", previewApi: true).Result;
+            var au = cd.authenticatedUser;
+
+            var account = new Account();
+            account.accountId = au.id;
+            account.accountName = au.Account;
+            account.properties = new Dictionary<string, object>();
+            account.properties.Add("Mail", account.accountName);
+            
+            var raccount = new Resource<Account>();
+            raccount.count = 1;
+            var valList = new List<Account>();
+            valList.Add(account);
+            raccount.value = valList;
+            
+            return Task.FromResult(raccount);
         }
 
         public Task<Resource<Account>> GetUserByMail(string email)

--- a/NuKeeper.AzureDevOps/AzureDevopsRestTypes.cs
+++ b/NuKeeper.AzureDevOps/AzureDevopsRestTypes.cs
@@ -65,6 +65,60 @@ namespace NuKeeper.AzureDevOps
         public string descriptor { get; set; }
     }
 
+    public class UserAccount
+    {
+        public string id { get; set; }
+        public string descriptor { get; set; }
+        public string subjectDescriptor { get; set; }
+        public string providerDisplayName { get; set; } //  ex: Steven Maglio
+        public bool isActive { get; set; }
+        public Dictionary<string, object> properties { get; set; } // ex: "Account": { "$type": "System.String", "$value": "MAGLIO-S@sa.ucsb.edu" }
+        public int resourceVersion { get; set; }
+        public int metaTypeId { get; set; }
+        public string Account
+        {
+            get
+            {
+                if (properties.ContainsKey("Account"))
+                {
+                    switch (properties["Account"])
+                    {
+                        case JObject acctObject:
+                            return acctObject.Property("$value").Value.ToString();
+
+                        case JProperty acctProp:
+                            return acctProp.Value.ToString();
+
+                        case string acctString:
+                            return acctString;
+                    }
+                }
+
+                return string.Empty;
+            }
+        }
+
+    }
+
+    public class LocationServiceData
+    {
+        public string serviceOwner { get; set; }
+        public string defaultAccessMappingMoniker { get; set; }
+        public long lastChangeId { get; set; }
+        public long lastChangeId64 { get; set; }
+    }
+    
+
+    public class ConnectionData
+    {
+        public UserAccount authenticatedUser { get; set; }
+        public UserAccount authorizedUser { get; set; }
+        public string instanceId { get; set; }
+        public string deploymentId { get; set; }
+        public string deploymentType { get; set; }
+        public LocationServiceData locationServiceData { get; set; }
+}
+
     public class GitRefs
     {
         public string name { get; set; }

--- a/NuKeeper.Git.Tests/NuKeeper.Git.Tests.csproj
+++ b/NuKeeper.Git.Tests/NuKeeper.Git.Tests.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <PropertyGroup>
-    <NoWarn>1701;1702;CA2007</NoWarn>
+    <NoWarn>1701;1702;CA2007;CA1416</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/NuKeeper.GitHub.Tests/NuKeeper.GitHub.Tests.csproj
+++ b/NuKeeper.GitHub.Tests/NuKeeper.GitHub.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <PropertyGroup>

--- a/NuKeeper.GitHub/NuKeeper.GitHub.csproj
+++ b/NuKeeper.GitHub/NuKeeper.GitHub.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Octokit" Version="0.50.0" />
   </ItemGroup>
 

--- a/NuKeeper.Gitea.Tests/NuKeeper.Gitea.Tests.csproj
+++ b/NuKeeper.Gitea.Tests/NuKeeper.Gitea.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <PropertyGroup>

--- a/NuKeeper.Gitlab.Tests/NuKeeper.Gitlab.Tests.csproj
+++ b/NuKeeper.Gitlab.Tests/NuKeeper.Gitlab.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/NuKeeper.Inspection.Tests/NuKeeper.Inspection.Tests.csproj
+++ b/NuKeeper.Inspection.Tests/NuKeeper.Inspection.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <PropertyGroup>

--- a/NuKeeper.Integration.Tests/NuKeeper.Integration.Tests.csproj
+++ b/NuKeeper.Integration.Tests/NuKeeper.Integration.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <CodeAnalysisRuleSet>..\CodeAnalysisRulesForTests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>

--- a/NuKeeper.Tests/NuKeeper.Tests.csproj
+++ b/NuKeeper.Tests/NuKeeper.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <CodeAnalysisRuleSet>..\CodeAnalysisRulesForTests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>

--- a/NuKeeper.Update.Tests/NuKeeper.Update.Tests.csproj
+++ b/NuKeeper.Update.Tests/NuKeeper.Update.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
 	</PropertyGroup>
   <PropertyGroup>

--- a/NuKeeper/Commands/CommandBase.cs
+++ b/NuKeeper/Commands/CommandBase.cs
@@ -287,7 +287,7 @@ namespace NuKeeper.Commands
             {
                 if (!BranchNamer.IsValidTemplateToken(token))
                 {
-                    tokenErrors.Append($",{token}");
+                    tokenErrors.Append(Language.enUS, $",{token}");
                 }
             }
 

--- a/NuKeeper/ContainerRegistration.cs
+++ b/NuKeeper/ContainerRegistration.cs
@@ -52,9 +52,7 @@ namespace NuKeeper
                     var httpMessageHandler = new HttpClientHandler();
                     if (httpMessageHandler.SupportsAutomaticDecompression)
                     {
-                        // TODO: change to All when moving to .NET 5.0
-                        httpMessageHandler.AutomaticDecompression =
-                            DecompressionMethods.GZip | DecompressionMethods.Deflate;
+                        httpMessageHandler.AutomaticDecompression = DecompressionMethods.All;
                     }
 
                     return httpMessageHandler;

--- a/NuKeeper/Engine/DefaultCommitWorder.cs
+++ b/NuKeeper/Engine/DefaultCommitWorder.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using NuGet.Packaging.Core;
@@ -87,7 +88,7 @@ namespace NuKeeper.Engine
 
             var projectOptS = (projects.Count > 1) ? "s" : string.Empty;
 
-            builder.AppendLine($"{updates.Count} packages were updated in {projects.Count} project{projectOptS}:");
+            builder.AppendLine(Language.enUS, $"{updates.Count} packages were updated in {projects.Count} project{projectOptS}:");
             builder.AppendLine(packageNames);
             builder.AppendLine("<details>");
             builder.AppendLine("<summary>Details of updated packages</summary>");
@@ -122,12 +123,12 @@ namespace NuKeeper.Engine
 
             if (oldVersions.Count == 1)
             {
-                builder.AppendLine($"NuKeeper has generated a {changeLevel} update of {packageId} to {newVersion} from {oldVersions.JoinWithCommas()}");
+                builder.AppendLine(Language.enUS, $"NuKeeper has generated a {changeLevel} update of {packageId} to {newVersion} from {oldVersions.JoinWithCommas()}");
             }
             else
             {
-                builder.AppendLine($"NuKeeper has generated a {changeLevel} update of {packageId} to {newVersion}");
-                builder.AppendLine($"{oldVersions.Count} versions of {packageId} were found in use: {oldVersions.JoinWithCommas()}");
+                builder.AppendLine(Language.enUS, $"NuKeeper has generated a {changeLevel} update of {packageId} to {newVersion}");
+                builder.AppendLine(Language.enUS, $"{oldVersions.Count} versions of {packageId} were found in use: {oldVersions.JoinWithCommas()}");
             }
 
             if (updates.Selected.Published.HasValue)
@@ -137,7 +138,7 @@ namespace NuKeeper.Engine
                 var pubDate = updates.Selected.Published.Value.UtcDateTime;
                 var ago = TimeSpanFormat.Ago(pubDate, DateTime.UtcNow);
 
-                builder.AppendLine($"{packageWithVersion} was published at {pubDateString}, {ago}");
+                builder.AppendLine(Language.enUS, $"{packageWithVersion} was published at {pubDateString}, {ago}");
             }
 
             var highestVersion = updates.Packages.Major?.Identity.Version;
@@ -154,7 +155,7 @@ namespace NuKeeper.Engine
             }
             else
             {
-                builder.AppendLine($"{updates.CurrentPackages.Count} project updates:");
+                builder.AppendLine(Language.enUS, $"{updates.CurrentPackages.Count} project updates:");
             }
 
             foreach (var current in updates.CurrentPackages)
@@ -211,7 +212,7 @@ namespace NuKeeper.Engine
 
             var highestPublishedAt = HighestPublishedAt(updates.Packages.Major.Published);
 
-            builder.AppendLine(
+            builder.AppendLine(Language.enUS,
                 $"There is also a higher version, {highest}{highestPublishedAt}, " +
                 $"but this was not applied as only {allowedChange} version changes are allowed.");
         }

--- a/NuKeeper/Language.cs
+++ b/NuKeeper/Language.cs
@@ -1,0 +1,9 @@
+using System.Globalization;
+
+namespace NuKeeper
+{
+    public static class Language
+    {
+        public static readonly CultureInfo enUS = new CultureInfo("en-US");
+    }
+}

--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>
     <PackageId>nukeeper</PackageId>

--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -12,14 +12,16 @@
     <CodeAnalysisRuleSet>..\CodeAnalysisRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NuGet.Credentials" Version="5.11.0" />
     <PackageReference Include="SimpleInjector" Version="5.3.2" />
     <PackageReference Include="SimpleInjector.Integration.ServiceCollection" Version="5.3.0" />
   </ItemGroup>
   <ItemGroup>
     <!-- Ship NuGet CLI -->
-    <PackageReference Include="NuGet.CommandLine" Version="5.11.0" PrivateAssets="all" ExcludeAssets="all" GeneratePathProperty="true" />
+    <PackageReference Include="NuGet.CommandLine" Version="6.13.1" PrivateAssets="all" ExcludeAssets="all" GeneratePathProperty="true">
+      <IncludeAssets>none</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NuKeeper.Abstractions\NuKeeper.Abstractions.csproj" />

--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net5.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>
     <PackageId>nukeeper</PackageId>

--- a/NuKeeper/NuKeeper.csproj
+++ b/NuKeeper/NuKeeper.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="NuGet.Credentials" Version="5.11.0" />
+    <PackageReference Include="NuGet.Credentials" Version="6.13.1" />
     <PackageReference Include="SimpleInjector" Version="5.3.2" />
     <PackageReference Include="SimpleInjector.Integration.ServiceCollection" Version="5.3.0" />
   </ItemGroup>

--- a/Nukeeper.AzureDevOps.Tests/Nukeeper.AzureDevOps.Tests.csproj
+++ b/Nukeeper.AzureDevOps.Tests/Nukeeper.AzureDevOps.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/nukeeper.settings.json
+++ b/nukeeper.settings.json
@@ -1,0 +1,15 @@
+{
+	"age": "0d",
+	"platform": "AzureDevOps",
+	"api": "https://dev.azure.com/sist-sa-ucsb",
+	"fork": "SingleRepository",
+	"consolidate": true,
+	"include": ".*",
+	"label": [ "automated", "nukeeper" ],
+	"change": "major",
+	"maxPackageUpdates": 25,
+	"outputFormat": "Text",
+	"sa_jiraprojectkey": "ARPRCORE",
+	"sa_jiraassignee": "maglio-s@sa.ucsb.edu",
+	"sa_autocompletepr": true
+}


### PR DESCRIPTION
* Updated to target `net8.0`
* Updated `NuGet.*` dependencies to `6.13.1`
* "Fixed" AzureDevOps `GetCurrentUser()` to use a different/non-deprecated API endpoint.